### PR TITLE
One Watcher to rule them all

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,10 +6,8 @@
     "frameworkStyles": "framework/styles",
     "content": "content",
     "data": "site/data",
-    "templates": [
-      "framework/templates",
-      "site/templates"
-    ],
+    "templates": "site/templates",
+    "frameworkTemplates": "framework/templates",
     "helpers": [
       "framework/helpers",
       "site/helpers"

--- a/lib/core/Loader.js
+++ b/lib/core/Loader.js
@@ -73,7 +73,6 @@ define([
         var cache = new Cache(config.json);
         var watcher = new Watcher(config.json);
 
-        self.bindTo(templates, 'changed', crawler.updateTemplate);
         self.bindTo(crawler, 'changed', queue.add);
         self.bindTo(server, 'fromCache', cache.find);
         self.bindTo(queue, 'processed', cache.set);
@@ -83,6 +82,8 @@ define([
         self.bindTo(cache, 'found', server.respond);
         self.bindTo(helpers, 'queue', queue.add);
         self.bindTo(watcher, 'queue', queue.add);
+        self.bindTo(watcher, 'changed:template', templates.readTemplates);
+        self.bindTo(watcher, 'changed:page', crawler.update);
 
         self.bindOnceTo(queue, 'empty', starting.done);
 

--- a/lib/core/Signature.js
+++ b/lib/core/Signature.js
@@ -1,5 +1,5 @@
 /*
-  
+
   signature animator class
 
   uses logger to animate framework header signature
@@ -33,6 +33,7 @@ define([
       var rows = _.toArray(self.rows);
       var padding = '            ';
       var buffer = '\n' + padding;
+      var delay = self.options.animateIntro == false ? 5 : 25;
 
       function render () {
 
@@ -54,7 +55,7 @@ define([
             rows.shift();
           }
 
-          _.delay(render, 25);
+          _.delay(render, delay);
         }
         else {
 
@@ -67,7 +68,8 @@ define([
       };
 
       self.logger.clear();
-      _.delay(render, 250);
+
+      render();
     }
   });
 });

--- a/lib/nodes/Crawler.js
+++ b/lib/nodes/Crawler.js
@@ -56,6 +56,12 @@ define([
       self.filesystem.readDirectory(path, self.readNode);
     },
 
+    'update': function (s) {
+
+      var self = this;
+      console.log('sss>', s);process.exit(1);
+    },
+
     'triggerUpdated': function (node) {
 
       var self = this;
@@ -74,85 +80,35 @@ define([
 
       _.defer(function () {
 
-        self.filesystem.watchTree(path, function (changed) {
+        var notFoundUrl = '/404';
 
-          if (typeof changed === 'string') {
+        if (!self.map[notFoundUrl]) {
 
-            var options = {
-              'url': _.initial(changed.replace(path, '').split('/')).join('/') || '/'
-            };
-            PageNode.prototype.parsePosition.apply(options);
-
-            var node = self.map[options.url];
-
-            if (node) {
-              node.updateMetaNode(changed);
+          var meta = {};
+          meta[self.options.localization.defaultLangCode] = {
+            'meta': {
+              'template': '404'
             }
-            else {
-              throw new Error('Failed to find existing page node @ ' + options.url);
-            }
-          }
-          else {
+          };
 
-            var notFoundUrl = '/404';
+          self.map[notFoundUrl] = {
+            'nodeType': 'page',
+            'url': notFoundUrl,
+            'meta': meta
+          };
+        }
 
-            if (!self.map[notFoundUrl]) {
-
-              var meta = {};
-              meta[self.options.localization.defaultLangCode] = {
-                'meta': {
-                  'template': '404'
-                }
-              };
-
-              self.map[notFoundUrl] = {
-                'nodeType': 'page',
-                'url': notFoundUrl,
-                'meta': meta
-              };
-            }
-
-            _.each(self.map, function (node, url) {
-              if (!node.meta[self.options.localization.defaultLangCode]) {
-                delete self.map[url];
-              }
-            });
-
-            crawling.done();
-            done.resolve(self.map, self.paths);
+        _.each(self.map, function (node, url) {
+          if (!node.meta[self.options.localization.defaultLangCode]) {
+            delete self.map[url];
           }
         });
+
+        crawling.done();
+        done.resolve(self.map, self.paths);
       });
 
       return done.promise();
-    },
-
-    'updateTemplate': function (templateName, templates) {
-
-      var self = this;
-      var changed = {};
-      var logger = self.logger.wait('Templates', 'The template "' + templateName + '" was changed and invalidated 0 page(s)');
-      var partial = '{{>' + templateName + '}}';
-
-      _.each(self.map, function (node, url) {
-
-        _.each(node.meta, function (meta, langCode) {
-
-          if (templateName === meta.meta.template || templates[meta.meta.template].raw.indexOf(partial) >= 0) {
-            changed[url] = node;
-          }
-        });
-      });
-
-      if (!_.size(changed)) {
-        return logger.remove();
-      }
-
-      _.each(changed, function (node, url) {
-
-        self.trigger('changed', node);
-        logger.nextAndDone();
-      });
     }
   });
 });

--- a/lib/nodes/Watcher.js
+++ b/lib/nodes/Watcher.js
@@ -29,23 +29,42 @@ define([
       self.registry = {};
     },
 
-    'watch': function (url, type, data) {
+    'watch': function (url, data, output) {
 
       var self = this;
+      var type = data.nodeType;
+      url = url.replace(/\/\//g, '/');
 
       if (url.indexOf('.js') > 0) {
-        self.watchAppBundle(url, data);
+        self.watchAppBundle(url, output, data);
       }
       else if (url.indexOf('.css') > 0) {
-        self.watchStyleSheet(url, data);
+        self.watchStyleSheet(url, output, data);
+      }
+      else if (type === 'page') {
+        self.watchPage(url, output, data);
       }
     },
 
-    'watchStyleSheet': function (url, data) {
+    'watchPage': function (url, output, data) {
 
       var self = this;
       var dependencies = [];
-      url = url.replace(/\/\//g, '/');
+      var contentDir = self.options.paths.content;
+      var templateDir = self.options.paths.templates;
+
+      var path = (self.options.realPaths[url] || url) + '/' + data.meta.template + '.txt';
+      dependencies.push(path);
+      dependencies.push(templateDir + '/' + data.meta.template + '.tmpl');
+
+      self.register(url, 'page', dependencies);
+      // console.log(self.registry);process.exit(1);
+    },
+
+    'watchStyleSheet': function (url, output, data) {
+
+      var self = this;
+      var dependencies = [];
 
       function findNextStyleSheet (haystack, filename) {
 
@@ -54,6 +73,7 @@ define([
         var name;
 
         if (match && typeof match === 'string') {
+
           name = match.replace('@import "', '').replace('"', '');
           if (name.indexOf(self.options.paths.styles) < 0) {
             name = self.options.paths.styles + '/' + name;
@@ -88,7 +108,7 @@ define([
       };
     },
 
-    'watchAppBundle': function (url, data) {
+    'watchAppBundle': function (url, output, data) {
 
       var self = this;
       var dependencies = [];
@@ -105,7 +125,7 @@ define([
         }
       }
 
-      findNextAppBundle(data);
+      findNextAppBundle(output);
 
       self.register(url, 'appBundle', dependencies);
     },
@@ -121,6 +141,74 @@ define([
       self.filesystem.watchTree('./', self.handleChange);
     },
 
+    'getTypeFromPath': function (path) {
+
+      var self = this;
+
+      if (path.indexOf('.tmpl') > 0) {
+        return 'template';
+      }
+
+      if (path.indexOf('.js') > 0) {
+        return 'appBundle';
+      }
+
+      if (path.indexOf(self.options.paths.content) === 0) {
+        return 'page';
+      }
+
+
+      console.log(path);process.exit(1)
+    },
+
+    // 'templateWasChanged': function (path) {
+
+    //   var self = this;
+    //   self.trigger('changed:template');
+    //   self.forDependenciesOf(path, self.triggerQueue);
+    // },
+
+    // 'pageWasChanged': function (path) {
+
+    //   var self = this;
+    //   self.trigger()
+    //   console.log(path);process.exit(1)
+    // },
+
+    'triggerQueue': function (job) {
+
+      var self = this;
+      var name = job.url.replace('/applications/', '').replace('/Application.js', '').replace(self.options.paths.styles, '').replace('.css', '').replace('//', '');
+
+      self.logger.log('triggerQueue:' + job.nodeType + ' >>> ' + name + ' ::: ' + job.url);
+
+      self.trigger('queue', {
+        'nodeType': job.nodeType,
+        'name': name,
+        'url': job.url
+      });
+    },
+
+    'forDependenciesOf': function (path, callback) {
+
+      var self = this;
+      var dependencies = self.registry[path] || [];
+      var loggers = {};
+
+      while (dependencies.length) {
+
+        dep = dependencies.shift();
+
+        if (!loggers[dep.nodeType] || loggers[dep.nodeType].isDone) {
+          loggers[dep.nodeType] = self.logger.wait(self.namespace, 'The file "' + path + '" changed and invalidated 0 ' + dep.nodeType + '(s)');
+        }
+
+        callback(dep);
+
+        loggers[dep.nodeType].nextAndDone();
+      }
+    },
+
     'handleChange': function (changed) {
 
       var self = this;
@@ -133,10 +221,28 @@ define([
         throw new Error('Config file ' + changed + ' was changed, crashing server process');
       }
 
+      var type = self.getTypeFromPath(changed);
+      self.trigger('changed:' + type, changed);
+
+      self.forDependenciesOf(changed, self.triggerQueue);
+
+      return;
+      // var strategy = self[type + 'WasChanged'];
+
+      // if (typeof strategy !== 'function') {
+      //   throw new Error('Invalid change handler for type ' + type);
+      // }
+
+      // return strategy(changed);
+
+
       changed = changed.replace('.js', '');
+      changed = changed.replace(self.options.paths.content + '/', '');
 
       var dependencies = self.registry[changed] || [];
       var dep, logger, name;
+
+      // console.log(changed, dependencies);console.log(self.registry);process.exit(1);
 
       while (dependencies.length) {
 
@@ -173,26 +279,39 @@ define([
 
         dep = self.resolveUrl(dep);
 
+        self.logger.log('register:' + dep);
+
+        if (!dep) {
+          return;
+        }
+
         if (!self.registry[dep]) {
           self.registry[dep] = [];
         }
 
-        self.registry[dep].push({
-          'url': url,
-          'nodeType': type
+        var existing = _.find(self.registry[dep], function (_dep) {
+
+          return _dep.url === url;
         });
 
-        logger.nextAndDone();
+        if (!existing) {
+          self.registry[dep].push({
+            'url': url,
+            'nodeType': type
+          });
+
+          logger.nextAndDone();
+        }
       }
 
       _.each(dependencies, register);
 
-      register(url);
+      self.logger.json(self.registry)
     },
 
     'resolveUrl': function (url) {
 
-      if (url[0] === '/') {
+      if (url.indexOf('.') > 0 && url[0] === '/') {
         url = url.replace('/', '');
       }
 

--- a/lib/render/AppBundleRenderJob.js
+++ b/lib/render/AppBundleRenderJob.js
@@ -1,5 +1,5 @@
 /*
-  
+
   app bundle render job class
 
   creates minified javascript application bundle
@@ -15,7 +15,7 @@ define([
 ], function (Base, _, handlebars) {
 
   var _super = Base.prototype;
-  
+
   return Base.extend({
 
     'namespace': 'Render',
@@ -45,7 +45,7 @@ define([
         self.filesystem.recursiveDelete(tempName);
 
         data.logger.nextAndDone();
-        deferred.resolve(content, data.url);
+        deferred.resolve(data.url, content, data);
       }).fail(function (err, output) {
 
         throw new Error('Failed to create application bundle @ ' + path + err + output);

--- a/lib/render/PageRenderJob.js
+++ b/lib/render/PageRenderJob.js
@@ -61,49 +61,72 @@ define([
       return raw;
     },
 
-    'run': function (data) {
+    'renderMeta': function (node, langCode) {
 
       var self = this;
       var options = self.options;
       var templates = options.templates;
-      var pages = {};
+      var meta = _.clone(node.meta);
+      var template = templates.models[meta.template];
+      var url = node.url;
 
-      _.each(data.meta, function (node, langCode) {
+      if (langCode !== options.localization.defaultLangCode) {
+        url = langCode + '/' + url;
+      }
 
-        var meta = _.clone(node.meta);
-        var template = templates.models[meta.template];
-        var url = data.url;
+      meta.langCode = node.langCode = langCode;
+      meta.url = url;
+      meta.page = meta;
+      meta.site = self.siteData.json;
+      meta.pkg = self.options.meta;
 
-        if (langCode !== options.localization.defaultLangCode) {
-          url = langCode + '/' + url;
+      self.trigger('rendering', url, meta);
+
+      _.each(meta, function (value, key) {
+
+        if (typeof value === 'string') {
+
+          var tmpl = handlebars.compile(value);
+          var result = tmpl(meta);
+          var markdown = self.markdown(result);
+          var clean = self.clean(markdown);
+
+          clean = new handlebars.SafeString(clean);
+          meta[key] = clean;
         }
-
-        node.url = url;
-        meta.page = meta;
-        meta.site = self.siteData.json;
-        meta.pkg = self.options.meta;
-
-        self.trigger('rendering', url, meta);
-
-        _.each(meta, function (value, key) {
-
-          if (typeof value === 'string') {
-
-            var tmpl = handlebars.compile(value);
-            var result = tmpl(meta);
-            var markdown = self.markdown(result);
-            var clean = self.clean(markdown);
-
-            clean = new handlebars.SafeString(clean);
-            meta[key] = clean;
-          }
-        });
-
-        var result = template.content(meta);
-        pages[url] = result;
       });
 
+      var result = template.content(meta);
+
+      node = _.merge({}, node, {
+        'nodeType': 'page'
+      });
+
+      return self.deferred().resolve(url, result, node);
+    },
+
+    'run': function (data) {
+
+      var self = this;
+      var pages = [];
+
+      // self.logger.log('=====');
+      // self.logger.json(data);
+
+      if (data.meta) {
+        _.each(data.meta, function (node, langCode) {
+          pages.push(self.renderMeta(node, langCode));
+        });
+      }
+      else if (data.langCode) {
+        pages.push(data, data.langCode);
+      }
+      else {
+        throw new Error('Invalid data for processing page render job');
+      }
+
       data.logger.nextAndDone();
+
       return pages;
     }
   });

--- a/lib/render/Queue.js
+++ b/lib/render/Queue.js
@@ -111,9 +111,10 @@ define([
 
       var job, result, verbose;
 
-      function whenProcessed (processed, url) {
+      function whenProcessed (url, processed, job) {
 
-        self.trigger('processed', url, job.nodeType, processed);
+        self.logger.log('processed:url:' + url);
+        self.trigger('processed', url, job, processed);
       }
 
       // The actual render loop
@@ -141,14 +142,14 @@ define([
             }
           });
         }
-        else if (_.isPlainObject(result)) {
+        // else if (_.isPlainObject(result)) {
 
-          _.each(result, whenProcessed);
+        //   _.each(result, whenProcessed);
 
-          if (!self.jobs.length) {
-            self.trigger('empty');
-          }
-        }
+        //   if (!self.jobs.length) {
+        //     self.trigger('empty');
+        //   }
+        // }
         else {
           throw new Error('Invalid render result');
         }
@@ -171,7 +172,7 @@ define([
       self.jobs = _.without(self.jobs, job);
 
       var processed = self.renderer.run(job)[url];
-      self.trigger('processed', url, job.nodeType, processed);
+      self.trigger('processed', url, job, processed);
     },
 
     'whenPageIsRendering': function (data) {

--- a/lib/render/StyleSheetRenderJob.js
+++ b/lib/render/StyleSheetRenderJob.js
@@ -59,7 +59,7 @@ define([
           }
 
           data.logger.nextAndDone();
-          deferred.resolve(result, data.url);
+          deferred.resolve(data.url, result, data);
         });
       }
       catch (e) {

--- a/lib/render/Templates.js
+++ b/lib/render/Templates.js
@@ -27,17 +27,22 @@ define([
       var self = this;
       _super.initialize.apply(self, arguments);
 
-      self.models = self.readTemplates();
+      self.models = {};
+      self.readTemplates();
     },
 
     'readTemplates': function () {
 
       var self = this;
-      var models = {};
+
+      var paths = [
+        self.options.paths.templates,
+        self.options.paths.frameworkTemplates
+      ];
 
       // TODO: allow for subfolders in the template folder!
 
-      _.each(self.options.paths.templates, function (path) {
+      _.each(paths, function (path) {
 
         path = path.replace('framework', self.options.frameworkDir);
 
@@ -48,29 +53,31 @@ define([
           var template = self.readTemplate(subPath, filename);
 
           if (template && template.name && template.content) {
-            models[template.name] = template;
+            self.models[template.name] = template;
             logger.nextAndDone();
           }
         });
 
-        self.filesystem.watchTree(path, function (changed) {
+        // TODO: move this to Watcher, only one watching process
 
-          if (typeof changed === 'string') {
+        // self.filesystem.watchTree(path, function (changed) {
 
-            var pieces = changed.split('/');
-            var name = pieces[pieces.length - 1].replace('.tmpl', '');
-            var template = self.readTemplate(changed, name + '.tmpl');
+        //   if (typeof changed === 'string') {
 
-            if (template && template.name && template.content) {
-              self.models[template.name] = template;
-            }
+        //     var pieces = changed.split('/');
+        //     var name = pieces[pieces.length - 1].replace('.tmpl', '');
+        //     var template = self.readTemplate(changed, name + '.tmpl');
 
-            self.trigger('changed', name, self.models);
-          }
-        });
+        //     if (template && template.name && template.content) {
+        //       self.models[template.name] = template;
+        //     }
+
+        //     self.trigger('changed', name, self.models);
+        //   }
+        // });
       });
 
-      return models;
+      self.logger.json(self.models);
     },
 
     'readTemplate': function (path, filename) {

--- a/lib/server/Cache.js
+++ b/lib/server/Cache.js
@@ -1,5 +1,5 @@
 /*
-  
+
   cache class
 
   holds all the cached assets and the information about them
@@ -15,7 +15,7 @@ define([
 ], function (Base, _) {
 
   var _super = Base.prototype;
-  
+
   return Base.extend({
 
     'namespace': 'Cache',
@@ -34,9 +34,10 @@ define([
       };
     },
 
-    'set': function (url, type, content) {
+    'set': function (url, data, content) {
 
       var self = this;
+      var type = data.nodeType;
       var existing = !!self.cache[url];
 
       self.cache[url] = {
@@ -62,7 +63,7 @@ define([
         }
 
         self.loggers.adding.nextAndDone();
-        
+
         self.options.logVerbose && self.logger.info(self.namespace, 'Adding new ' + type + ' @ ' + url);
         self.trigger('added', url, content);
       }

--- a/lib/server/Server.js
+++ b/lib/server/Server.js
@@ -49,7 +49,7 @@ define([
       app.use(self.lazyLoadMiddleware);
       app.listen(port);
 
-      self.logRunning();
+      setInterval(self.logRunning, 1000 * 15);
 
       starting.done();
     },
@@ -57,28 +57,20 @@ define([
     'logRunning': function (display) {
 
       var self = this;
+      var now = (new Date()).valueOf();
+      var delta = (now - self.started) / 1000;
+      var days = Math.floor(delta / 86400);
+      var hours = Math.floor(delta / 3600) % 24;
+      var minutes = Math.floor(delta / 60) % 60;
+      var seconds = Math.round(delta % 60);
 
-      if (display) {
+      var time = '';
+      days && (time += days + 'd ');
+      hours && (time += hours + 'h ');
+      minutes && (time += minutes + 'm ');
+      seconds && (time += seconds + 's ');
 
-        var now = (new Date()).valueOf();
-        var delta = (now - self.started) / 1000;
-        var days = Math.floor(delta / 86400);
-        var hours = Math.floor(delta / 3600) % 24;
-        var minutes = Math.floor(delta / 60) % 60;
-        var seconds = Math.round(delta % 60);
-
-        var time = '';
-        days && (time += days + 'd ');
-        hours && (time += hours + 'h ');
-        minutes && (time += minutes + 'm ');
-        seconds && (time += seconds + 's ');
-
-        self.logger.info(self.namespace, 'Server has been running for ' + time.trim() + ', received ' + self.requestCount + ' requests and sent ' + self.responseCount + ' non-error responses');
-      }
-
-      self.delay(function () {
-        self.logRunning(true);
-      }, 1000 * 60);
+      self.logger.info(self.namespace, 'Server uptime is ' + time.trim() + ' - received ' + self.requestCount + ' requests - sent ' + self.responseCount + ' non-error responses', false);
     },
 
     'resolveMiddleware': function (url) {


### PR DESCRIPTION
**when a folder in /content is added**
- [ ] crawl structure and add new pages

**when a folder in /content is removed**
- [ ] remove the url and all of its children from the map of available urls

**when a template is added**
- [ ] read and register as partial and template

**when a template is changed**
- [ ] the template must be re-read, an re-registered as a template and partial
- [ ] all pages using the template must be re-rendered
- [ ] all pages using a template that uses it as a partial must be re-rendered

**when a template is removed**
- [ ] remove the template from the registry, and partial if possible (maybe replace with an error function?)
- [ ] trigger template change, and let the missing template error come from the page render job

**when a content textfile is changed**
- [ ] trigger crawler to crawl parent page node and queue render

**when a content textfile is removed**
- [ ] trigger crawler to crawl parent page node and queue render

**when a content textfile is added**
- [ ] trigger crawler to crawl parent page node and queue render

**when a stylesheet or any of its imports changes**
- [ ] trigger new app bundle render

**when a app bundle or any of its dependencies changes**
- [ ] trigger new app bundle render

**About always rendering all meta nodes in a folder if one of them changes:** a coming feature of asimov.js is inheritance of properties between content meta nodes. And when that is implemented, all meta nodes will automatically inherit from the default language meta node.
